### PR TITLE
Add prepareSecure method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-for-node",
   "description": "Embracing a distributed web",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "homepage": "http://freedomjs.org",
   "bugs": {
     "url": "http://github.com/freedomjs/freedom-for-node/issues",

--- a/providers/tcpsocket.js
+++ b/providers/tcpsocket.js
@@ -78,6 +78,16 @@ TcpSocket_node.prototype.getInfo = function(callback) {
 };
 
 /**
+ * Prepares a socket for becoming secure, currently a no-op in node.
+ * Details at https://github.com/freedomjs/freedom/wiki/prepareSecure-API-Usage
+ * @method prepareSecure
+ * @param {Function} callback function to call on completion or error.
+ */
+TcpSocket_node.prototype.prepareSecure = function(callback) {
+  callback();
+};
+
+/**
  * Secure a socket, such that subsequent methods are sent over a TLS channel.
  * @method secure
  * @param {Function} callback function to call on completion or error.


### PR DESCRIPTION
Add prepareSecure method to tcpsocket, to fix https://github.com/uProxy/uproxy/issues/413 - In freedom-for-chrome, this will call .setPaused, but in freedom-for-firefox and node this will be a no-op
