### PR TITLE
Fix TCP socket provider to pass the unit test.

### DIFF
--- a/providers/core.tcpsocket.js
+++ b/providers/core.tcpsocket.js
@@ -71,8 +71,8 @@ TcpSocket_node.prototype.getInfo = function (callback) {
       connected: this.connection.state === TcpSocket_node.state.CONNECTED,
       peerAddress: this.connection.remoteAddress,
       peerPort: this.connection.remotePort,
-      localAddress: this.connection.localAddress,
-      localPort: this.connection.localPort
+      localAddress: this.connection.address().address,
+      localPort: this.connection.address().port
     });
   }
 };


### PR DESCRIPTION
The provider was using |connection.localAddress| to populate the response
from getInfo, but node does not fill in |localAddress| for server sockets.
However, both client and server sockets provide their local address
through the |address()| getter.