### PR TITLE
extending context to overall freedom whitelist

### DIFF
--- a/lib/modulecontext.js
+++ b/lib/modulecontext.js
@@ -1,18 +1,20 @@
 /*jslint node:true, sloppy:true */
-/*globals Uint8Array,Uint16Array,ArrayBuffer,DataView*/
+/*globals escape,unescape*/
 
 var vm = require('vm');
 var fs = require('fs');
 var crypto = require('crypto');
 var NodeLink = require('./link');
 var link = new NodeLink();
+var es6promise = require('es6-promise').Promise;
+var Intl = require('intl');
 
 // compute freedom.js source.
 var src = fs.readFileSync(require.resolve('freedom/freedom'));
 
 var freedomVM;
 
-// Create Minimal Context.
+// Create Base Context.
 var context = {
   // setTimeout - for delaying async / implementing promises.
   setTimeout: function (cb, time) {
@@ -41,10 +43,46 @@ var context = {
       context._om = cb;
     }
   },
+  Array: Array,
   ArrayBuffer: ArrayBuffer,
+  Boolean: Boolean,
   DataView: DataView,
+  Date: Date,
+  Error: Error,
+  Float32Array: Float32Array,
+  Float64Array: Float64Array,
+  Infinity: Infinity,
+  Int8Array: Int8Array,
+  Int16Array: Int16Array,
+  Int32Array: Int32Array,
+  Intl: Intl,
+  JSON: JSON,
+  Math: Math,
+  NaN: NaN,
+  Number: Number,
+  Object: Object,
+  Promise: es6promise,
+  RangeError: RangeError,
+  RegExp: RegExp,
+  String: String,
+  SyntaxError: SyntaxError,
+  URIError: URIError,
   Uint8Array: Uint8Array,
   Uint16Array: Uint16Array,
+  Uint32Array: Uint32Array,
+  Uint8ClampedArray: Uint8ClampedArray,
+  console: console,
+  decodeURI: decodeURI,
+  decodeURIComponent: decodeURIComponent,
+  encodeURI: encodeURI,
+  encodeURIComponent: encodeURIComponent,
+  escape: escape,
+  isFinite: isFinite,
+  isNaN: isNaN,
+  parseFloat: parseFloat,
+  parseInt: parseInt,
+  undefined: undefined,
+  unescape: unescape,
   Buffer: Buffer,
   crypto: {
       getRandomValues: function (typedarray) {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "freedom": "~0.6.18",
     "glob": "~4.3.1",
     "grunt-contrib-jshint": "^0.10.0",
+    "intl": "^0.1.4",
     "json-store": "0.0.1",
     "node-json-minify": "^0.1.3-a",
     "tls-connect": "^0.2.2"


### PR DESCRIPTION
Same list as: https://github.com/freedomjs/freedom/blob/soycode-webworker-masking/src/link/worker.js#L68

Depends on two polyfills (promises and intl). Allows end-to-end to work in freedom-for-node.