### PR TITLE
node message payloads now are in .data field

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -110,12 +110,15 @@ NodeLink.prototype.deliverMessage = function(flow, message) {
 NodeLink.prototype.fix = function(message) {
   if (message && message.message && message.message.message) {
     message.message.message = this.replaceBuffers(message.message.message);
-    //console.log(message.message.message);
   }
   if (message && message.message && message.message.binary) {
     var out = [], i = 0;
     for (i = 0; i < message.message.binary.length;i += 1) {
-      out.push(new Uint8Array(message.message.binary[i]).buffer);
+      if (process.versions.node < '0.12') {
+        out.push(new Uint8Array(message.message.binary[i]).buffer);
+      } else {
+        out.push(new Uint8Array(message.message.binary[i].data).buffer);
+      }
     }
     message.message.binary = out;
   }


### PR DESCRIPTION
After much investigation, it looks like the issue is that node 0.12 takes what used to be message payloads and wraps them in objects like `{ 'type': 'Buffer', 'data': oldmessage }`.

This code handles that with version checking to still do the old thing in 0.10 (since that's what is still in Ubuntu stable, etc.). Checked and with this patch https://github.com/freedomjs/freedom-pgp-e2e/ integration tests pass in both versions of node (and even iojs 1.6.2).