### PR TITLE
mark accepted sockets as connected

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,11 +25,13 @@ var providers = [
   xhr,
   require('freedom/providers/core/core.rtcdatachannel.js')
 ];
-if (process.platform !== 'darwin') {
+try {
   // webrtc doesn't build on osx right now
   var rtcpeer = require('freedom/providers/core/core.rtcpeerconnection.js');
   rtcpeer.setImpl(require('wrtc'));
   providers.push(rtcpeer);
+} catch(e) {
+  console.warn('Failed to load wrtc, will not have WebRTC support');
 }
 
 if (!module.parent) {

--- a/index.js
+++ b/index.js
@@ -10,9 +10,6 @@ var websocket = require('freedom/providers/core/core.websocket');
 var xhr = require('freedom/providers/core/core.xhr');
 websocket.setSocket(require('ws'), true);
 xhr.setImpl(require('xhr2'));
-var rtcpeer = require('freedom/providers/core/core.rtcpeerconnection.js');
-rtcpeer.setImpl(require('wrtc'));
-
 var providers = [
   require('freedom/providers/core/core.unprivileged'),
   require('freedom/providers/core/core.echo'),
@@ -26,9 +23,14 @@ var providers = [
   require('freedom/providers/core/core.oauth'),
   websocket,
   xhr,
-  rtcpeer,
   require('freedom/providers/core/core.rtcdatachannel.js')
 ];
+if (process.platform !== 'darwin') {
+  // webrtc doesn't build on osx right now
+  var rtcpeer = require('freedom/providers/core/core.rtcpeerconnection.js');
+  rtcpeer.setImpl(require('wrtc'));
+  providers.push(rtcpeer);
+}
 
 if (!module.parent) {
   require('./lib/modulecontext');

--- a/providers/core.tcpsocket.js
+++ b/providers/core.tcpsocket.js
@@ -360,17 +360,18 @@ TcpSocket_node.prototype.onAccept = function (connection) {
  * @param {Function} continuation Function to call once socket is disconnected.
  */
 TcpSocket_node.prototype.close = function (continuation) {
-  if (this.connection) {
-    if (this.state === TcpSocket_node.state.BINDING ||
-        this.state === TcpSocket_node.state.LISTENING) {
-      try {
-        // Close client socket
-        this.connection.end();
-      } catch(e) {
+  if (this.connection && this.state !== TcpSocket_node.state.CLOSED) {
+    try {
+      if (this.state === TcpSocket_node.state.LISTENING) {
         // Close server socket
         this.connection.close();
+      } else {
+        // Close client socket
+        this.connection.end();
       }
-    } else {
+    } catch(e) {
+      // Definitely close one way or another
+      console.warn("Had to destroy socket " + this.id);
       this.connection.destroy();
     }
     delete this.connection;

--- a/providers/core.tcpsocket.js
+++ b/providers/core.tcpsocket.js
@@ -50,15 +50,16 @@ TcpSocket_node.state = {
  * @param {Function} callback Function to call after completion or error.
  */
 TcpSocket_node.prototype.write = function (data, callback) {
-  if (this.state !== TcpSocket_node.state.CONNECTED) {
+  if (this.state === TcpSocket_node.state.CONNECTED ||
+      this.state === TcpSocket_node.state.LISTENING) {
+    var buffer = new Buffer(new Uint8Array(data));
+    this.connection.write(buffer, 'utf8', callback);
+  } else {
     callback(undefined, {
       "errcode": "NOT_CONNECTED",
       "message": "Cannot Write on Closed Socket"
     });
-    return;
   }
-  var buffer = new Buffer(new Uint8Array(data));
-  this.connection.write(buffer, 'utf8', callback);
 };
 
 /**
@@ -67,15 +68,16 @@ TcpSocket_node.prototype.write = function (data, callback) {
  * @param {Function} callback Function to call after pausing the socket.
  */
 TcpSocket_node.prototype.pause = function (callback) {
-  if (this.state !== TcpSocket_node.state.CONNECTED) {
+  if (this.state === TcpSocket_node.state.CONNECTED ||
+      this.state === TcpSocket_node.state.LISTENING) {
+    this.connection.pause();
+    callback();
+  } else {
     callback(undefined, {
       "errcode": "NOT_CONNECTED",
       "message": "Cannot pause a closed socket"
     });
-    return;
   }
-  this.connection.pause();
-  callback();
 };
 
 /**
@@ -84,15 +86,16 @@ TcpSocket_node.prototype.pause = function (callback) {
  * @param {Function} callback Function to call after resuming the socket.
  */
 TcpSocket_node.prototype.resume = function (callback) {
-  if (this.state !== TcpSocket_node.state.CONNECTED) {
+  if (this.state === TcpSocket_node.state.CONNECTED ||
+      this.state === TcpSocket_node.state.LISTENING) {
+    this.connection.resume();
+    callback();
+  } else {
     callback(undefined, {
       "errcode": "NOT_CONNECTED",
       "message": "Cannot resume a closed socket"
     });
-    return;
   }
-  this.connection.resume();
-  callback();
 };
 
 /**
@@ -133,33 +136,34 @@ TcpSocket_node.prototype.prepareSecure = function (callback) {
  * @param {Function} callback function to call on completion or error.
  */
 TcpSocket_node.prototype.secure = function (callback) {
-  if (this.state !== TcpSocket_node.state.CONNECTED) {
+  if (this.state === TcpSocket_node.state.CONNECTED ||
+      this.state === TcpSocket_node.state.LISTENING) {
+    var cleartext = this.tlsconnect({
+      socket: this.connection,
+      rejectUnauthorized: true,
+      requestCert: true,
+      isServer: false,
+      servername: this.servername
+    }, function () {
+      if (!cleartext.authorized) {
+        this.connection.destroy();
+        this.state = TcpSocket_node.state.CLOSED;
+        TcpSocket_node.connectionState[this.id] = this.state;
+        callback(undefined, {
+          "errcode": "CONNECTION_RESET",
+          "message": "Failed to secure socket."
+        });
+      } else {
+        this.upgradeConnection(cleartext);
+        callback();
+      }
+    }.bind(this));
+  } else {
     callback(undefined, {
       "errcode": "NOT_CONNECTED",
       "message": "Cannot secure closed socket"
     });
-    return;
   }
-  var cleartext = this.tlsconnect({
-    socket: this.connection,
-    rejectUnauthorized: true,
-    requestCert: true,
-    isServer: false,
-    servername: this.servername
-  }, function () {
-    if (!cleartext.authorized) {
-      this.connection.destroy();
-      this.state = TcpSocket_node.state.CLOSED;
-      TcpSocket_node.connectionState[this.id] = this.state;
-      callback(undefined, {
-        "errcode": "CONNECTION_RESET",
-        "message": "Failed to secure socket."
-      });
-    } else {
-      this.upgradeConnection(cleartext);
-      callback();
-    }
-  }.bind(this));
 };
 
 /**

--- a/providers/core.tcpsocket.js
+++ b/providers/core.tcpsocket.js
@@ -366,7 +366,8 @@ TcpSocket_node.prototype.close = function (continuation) {
   if (this.connection) {
     if (this.state === TcpSocket_node.state.BINDING ||
         this.state === TcpSocket_node.state.LISTENING) {
-      this.connection.close(continuation);
+      this.connection.end();
+      continuation();
     } else {
       this.connection.destroy();
       continuation();

--- a/providers/core.tcpsocket.js
+++ b/providers/core.tcpsocket.js
@@ -366,15 +366,23 @@ TcpSocket_node.prototype.close = function (continuation) {
   if (this.connection) {
     if (this.state === TcpSocket_node.state.BINDING ||
         this.state === TcpSocket_node.state.LISTENING) {
-      this.connection.end();
-      continuation();
+      try {
+        // Close server socket
+        this.connection.close();
+      } catch(e) {
+      }
+      try {
+        // Close client socket
+        this.connection.end();
+      } catch(e) {
+      }
     } else {
       this.connection.destroy();
-      continuation();
     }
     delete this.connection;
     this.state = TcpSocket_node.state.CLOSED;
     TcpSocket_node.connectionState[this.id] = this.state;
+    continuation();
   } else {
     continuation(undefined, {
       "errcode": "SOCKET_CLOSED",

--- a/providers/core.tcpsocket.js
+++ b/providers/core.tcpsocket.js
@@ -50,8 +50,7 @@ TcpSocket_node.state = {
  * @param {Function} callback Function to call after completion or error.
  */
 TcpSocket_node.prototype.write = function (data, callback) {
-  if (this.state === TcpSocket_node.state.CONNECTED ||
-      this.state === TcpSocket_node.state.LISTENING) {
+  if (this.state === TcpSocket_node.state.CONNECTED) {
     var buffer = new Buffer(new Uint8Array(data));
     this.connection.write(buffer, 'utf8', callback);
   } else {
@@ -68,8 +67,7 @@ TcpSocket_node.prototype.write = function (data, callback) {
  * @param {Function} callback Function to call after pausing the socket.
  */
 TcpSocket_node.prototype.pause = function (callback) {
-  if (this.state === TcpSocket_node.state.CONNECTED ||
-      this.state === TcpSocket_node.state.LISTENING) {
+  if (this.state === TcpSocket_node.state.CONNECTED) {
     this.connection.pause();
     callback();
   } else {
@@ -86,8 +84,7 @@ TcpSocket_node.prototype.pause = function (callback) {
  * @param {Function} callback Function to call after resuming the socket.
  */
 TcpSocket_node.prototype.resume = function (callback) {
-  if (this.state === TcpSocket_node.state.CONNECTED ||
-      this.state === TcpSocket_node.state.LISTENING) {
+  if (this.state === TcpSocket_node.state.CONNECTED) {
     this.connection.resume();
     callback();
   } else {
@@ -136,8 +133,7 @@ TcpSocket_node.prototype.prepareSecure = function (callback) {
  * @param {Function} callback function to call on completion or error.
  */
 TcpSocket_node.prototype.secure = function (callback) {
-  if (this.state === TcpSocket_node.state.CONNECTED ||
-      this.state === TcpSocket_node.state.LISTENING) {
+  if (this.state === TcpSocket_node.state.CONNECTED) {
     var cleartext = this.tlsconnect({
       socket: this.connection,
       rejectUnauthorized: true,
@@ -347,6 +343,7 @@ TcpSocket_node.prototype.listen = function (address, port, callback) {
 
 TcpSocket_node.prototype.onAccept = function (connection) {
   TcpSocket_node.unbound[this.id] = connection;
+  TcpSocket_node.connectionState[this.id] = TcpSocket_node.state.CONNECTED;
 
   this.dispatchEvent('onConnection', {
     'socket': this.id,
@@ -367,14 +364,11 @@ TcpSocket_node.prototype.close = function (continuation) {
     if (this.state === TcpSocket_node.state.BINDING ||
         this.state === TcpSocket_node.state.LISTENING) {
       try {
-        // Close server socket
-        this.connection.close();
-      } catch(e) {
-      }
-      try {
         // Close client socket
         this.connection.end();
       } catch(e) {
+        // Close server socket
+        this.connection.close();
       }
     } else {
       this.connection.destroy();

--- a/spec/provider.integration.spec.js
+++ b/spec/provider.integration.spec.js
@@ -32,21 +32,25 @@ describe("integration: storage.shared.json", require("freedom/spec/providers/sto
          .bind(this, require("../index").freedom, "../node_modules/freedom/providers/storage/shared/storage.shared.json", {}, false));
 
 // Transport
-xdescribe("integration: transport.webrtc.json",
-          require('freedom/spec/providers/transport/transport.integration.src')
-          .bind(this,
-                "providers/transport/webrtc/transport.webrtc.json", setup));
-describe("integration: core.rtcpeerconnection",
-         require('freedom/spec/providers/coreIntegration/rtcpeerconnection.integration.src')
-         .bind(this,
-               require("freedom/providers/core/core.rtcpeerconnection"),
-               require("freedom/providers/core/core.rtcdatachannel"),
-               setup));
+if (process.platform !== 'darwin') {
+  // webrtc doesn't build on osx right now
+  xdescribe("integration: transport.webrtc.json",
+            require('freedom/spec/providers/transport/transport.integration.src')
+            .bind(this,
+                  "providers/transport/webrtc/transport.webrtc.json", setup));
+  describe("integration: core.rtcpeerconnection",
+           require('freedom/spec/providers/coreIntegration/rtcpeerconnection.integration.src')
+           .bind(this,
+                 require("freedom/providers/core/core.rtcpeerconnection"),
+                 require("freedom/providers/core/core.rtcdatachannel"),
+                 setup));
+}
+
 describe("integration: core.tcpsocket",
-         require('freedom/spec/providers/coreIntegration/tcpsocket.integration.src').bind(this,
-                                                                                          require('../providers/core.tcpsocket'), setup));
+         require('freedom/spec/providers/coreIntegration/tcpsocket.integration.src').bind(
+           this, require('../providers/core.tcpsocket'), setup));
 var xhr = require('freedom/providers/core/core.xhr');
 xhr.setImpl(require('xhr2'));
 describe("integration: core.xhr", 
-         require("freedom/spec/providers/coreIntegration/xhr.integration.src").bind(this, 
-                                                                                    xhr, setup));
+         require("freedom/spec/providers/coreIntegration/xhr.integration.src").bind(
+           this, xhr, setup));


### PR DESCRIPTION
This fixes the echo node demo in uproxy - the issue was that the net/tcp.ts module is evidently using the same socket to listen and send, and these checks blocked that. But, it turns out it does in fact work if the checks are just made more liberal (and the existing freedom.js tests still pass).

I'm still not sure that this is the *correct* fix - possibly we want to keep the restrictions as they are here and instead change behavior in net/tcp.ts. But, this was significantly easier, so I figured it's worth initial consideration. Let me know your thoughts - thanks!

PS - My next step is to revisit the more sophisticated demos, will keep you posted.